### PR TITLE
feat: Integrate Jetpack Compose Multiplatform

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.android.application")
+    id("org.jetbrains.compose")
     kotlin("android")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,9 @@ plugins {
     //trick: for the same plugin versions in all sub-modules
     id("com.android.application").version("8.0.2").apply(false)
     id("com.android.library").version("8.0.2").apply(false)
-    kotlin("android").version("1.8.21").apply(false)
-    kotlin("multiplatform").version("1.8.21").apply(false)
+    id("org.jetbrains.compose").version("1.4.1").apply(false)
+    kotlin("android").version("1.8.20").apply(false)
+    kotlin("multiplatform").version("1.8.20").apply(false)
 }
 
 tasks.register("clean", Delete::class) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,7 @@ android.nonTransitiveRClass=true
 #MPP
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
+
+#Compose Multiplatform
+org.jetbrains.compose.experimental.uikit.enabled=true
+kotlin.native.cacheKind=none

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ pluginManagement {
     repositories {
         google()
         gradlePluginPortal()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
         mavenCentral()
     }
 }
@@ -10,6 +11,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("multiplatform")
     id("com.android.library")
+    id("org.jetbrains.compose")
     kotlin("plugin.serialization") version "1.8.22"
     id("app.cash.sqldelight") version "2.0.0-rc02"
 }
@@ -24,6 +25,7 @@ kotlin {
     ).forEach {
         it.binaries.framework {
             baseName = "shared"
+            isStatic = true
         }
     }
 
@@ -35,11 +37,24 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                //put your multiplatform dependencies here
+                // Compose
+                implementation(compose.runtime)
+                implementation(compose.foundation)
+                implementation(compose.material)
+                implementation(compose.materialIconsExtended)
+                implementation(compose.ui)
+                @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+                implementation(compose.components.resources)
+
+                // KotlinX
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
+
+                // Ktor
                 implementation("io.ktor:ktor-client-core:$ktorVersion")
                 implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
                 implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+
+                // KOIN
                 implementation("io.insert-koin:koin-core:$koinVersion")
             }
         }


### PR DESCRIPTION
**Summary**
I integrated Jetpack Compose v1.4.1 into the project, following the official documentation. Compose Multiplatform allows the creation of efficient and consistent UI components for Android and iOS using Kotlin Multiplatform.